### PR TITLE
Skip neighbor in normal calculation of boundary

### DIFF
--- a/source/derived/mus_stateVar_module.fpp
+++ b/source/derived/mus_stateVar_module.fpp
@@ -510,7 +510,7 @@ contains
         & nSrcElems   = nSrcElems,                                   &
         & point       = point(iPoint,:),                             &
         & statePos    = statePos,                                    &
-        & neigh       = fPtr%solverData%scheme%pdf(loc_level)%neigh, &
+        & neigh       = scheme%pdf(loc_level)%neigh,                 &
         & baryOfTotal = scheme%levelDesc(loc_level)%baryOfTotal,     &
         & nElems      = scheme%pdf(loc_level)%nSize,                 &
         & nSolve      = scheme%pdf(loc_level)%nElems_computed,       &

--- a/source/mus_connectivity_module.fpp
+++ b/source/mus_connectivity_module.fpp
@@ -354,7 +354,7 @@ contains
     !! halo elements for state vars
     logical, intent(in) :: excludeHalo
     ! --------------------------------------------------------------------------
-    integer :: iNeigh, neighPos
+    integer :: neighPos, iDir
     integer :: iSrc
     real(kind=rk) :: bary(3), dist(3), dist_len
     ! --------------------------------------------------------------------------
@@ -376,13 +376,13 @@ contains
     if ( dist_len .fne. 0.0_rk ) then
 
       ! get existing neighbor elements in actual tree
-      do iNeigh = 1, stencil%QQN
+      do iDir = 1, stencil%QQN
 
         ! Find neighor using neigh array because for boundary, neigh array
         ! points to current element so no need to check for existence of the
         ! neighbor element
         neighPos =                                                         &
-          & ?NghElemIDX?(neigh, iNeigh, stencil, statePos, nScalars, nElems)
+          & ?NghElemIDX?(neigh, iDir, stencil, statePos, nScalars, nElems)
 
         ! skip this neighbor and goto next neighbor
         if (excludeHalo .and. neighPos > nSolve) cycle
@@ -393,7 +393,7 @@ contains
           nSrcElems = nSrcElems + 1
           srcElemPos(nSrcElems)  = neighPos
         end if
-      end do !iNeigh
+      end do !iDir
 
       ! calculate weight
       do iSrc = 1, nSrcElems


### PR DESCRIPTION
If the neighbor itself is a boundary we skip it in the normal computation.