### PR TITLE
initialize radius and mass in particle config

### DIFF
--- a/source/particles/mus_particle_config_module.fpp
+++ b/source/particles/mus_particle_config_module.fpp
@@ -1170,8 +1170,8 @@ contains
     real(kind=rk) :: default_vel(6)
     real(kind=rk) :: force(6)
     real(kind=rk) :: velocity(6)
-    real(kind=rk) :: radius
-    real(kind=rk) :: mass
+    real(kind=rk) :: radius = 0.0_rk
+    real(kind=rk) :: mass = 0.0_rk
     logical :: has_init_velocity
     ! ---------------------------------------------------- !
     default_force = 0.0_rk


### PR DESCRIPTION
Compilation in recheck failed due to those
values being used uninitialized.
Now the values are initialized in the declaration and compilation
should succeed.
