### PR TITLE
Eliminate compilation groups to allow for proper partial builds

### DIFF
--- a/source/bc/mus_turb_wallFunc_module.f90
+++ b/source/bc/mus_turb_wallFunc_module.f90
@@ -486,7 +486,7 @@ contains
       ! Function of u_tau
       fx = velSW / velTau_old - wall_function%get_uPlus(yPlus)
       ! derivative of function w.r.t u_tau
-      dfdx = -velSW / velTau_old**2 -                                &
+      dfdx = -velSW / velTau_old**2                                  &
         &    - (wall_function%get_d_uPlus_d_uTau( y = y,             &
         &                                         uTau = velTau_old, &
         &                                         nu = nu            ) )

--- a/utests/mus_mrt_d3q19_matrix_test.f90
+++ b/utests/mus_mrt_d3q19_matrix_test.f90
@@ -59,11 +59,12 @@ program mus_mrt_d3q19_matrix_test
   end if
 
 contains
+
   subroutine check_error( a, b, nVals, tolerance, error )
     !---------------------------------------------------------------------------
+    integer, intent(in) :: nVals
     real(kind=rk), intent(in) :: a(nVals)
     real(kind=rk), intent(in) :: b(nVals)
-    integer, intent(in) :: nVals
     real(kind=rk), intent(in) :: tolerance
     logical, intent(out) :: error
     !---------------------------------------------------------------------------

--- a/wscript
+++ b/wscript
@@ -160,10 +160,11 @@ def build(bld):
 
       bld(
         features = 'coco fc fcprogram',
+        name     = 'musubi',
         source   = 'source/musubi.f90',
         use      = ['blas_objs', 'lapack_objs', 'tem_objs', bld.env.mpi_mem_c_obj,
                     'aotus', 'mus_objs']+extLib_objs,
-        target   = 'musubi')
+        target   = bld.path.parent.find_or_declare('musubi'))
 
       if bld.env.build_hvs and not bld.options.no_harvesting:
           mus_hvs_sources = bld.path.ant_glob('source/mus_harvesting/*.fpp')
@@ -175,10 +176,11 @@ def build(bld):
               target   = 'mus_hvs_objs')
           bld(
               features = 'fc fcprogram',
+              name     = 'mus_harvesting',
               source   = 'source/mus_harvesting/mus_harvesting.f90',
               use      = ['tem_objs', 'aotus', 'mus_objs', bld.env.mpi_mem_c_obj,
                           'mus_hvs_objs', 'base64']+extLib_objs,
-              target = 'mus_harvesting')
+              target = bld.path.parent.find_or_declare('mus_harvesting'))
 
       utests(bld, ['lapack_objs', 'aotus', 'tem_objs', bld.env.mpi_mem_c_obj,
                    'mus_objs','utest_objs']+extLib_objs, preprocessor='coco')


### PR DESCRIPTION
The use of build groups in the wscripts broke partial builds
and led to all sub project objects being built regardless of
the --target setting.
With this PR we eliminate those groups and allow for proper
building of those partial compilations again.
